### PR TITLE
fix: Prevent crash when using waitOn in Windows

### DIFF
--- a/src/lib/Misty.ts
+++ b/src/lib/Misty.ts
@@ -62,7 +62,7 @@ export default class Misty {
       command = `node ${path.join(__dirname, "../exec.js")} --name="${name}" --watchDir="${config.watchDir}" --cmd="${command}" ${config.cwd ? `--cwd=${config.cwd}` : ""} ${process.env.DEBUG ? `--debug=${process.env.DEBUG}` : ""}`;
 
       if (config.waitOn) {
-        command = `./node_modules/.bin/wait-on ${config.waitOn} && ${command}`;
+        command = `npx wait-on ${config.waitOn} && ${command}`;
       }
 
       commands.push({


### PR DESCRIPTION
Misty is crashing in Windows when using the waitOn option (see [https://github.com/Automattic/simplenote-electron/issues/1601](url)). This is due to `concurrently` somehow messing the command  `./node_modules/.bin/wait-on`, which works fine when run in isolation from the command prompt.

`npx wait-on` is a good alternative that prevents the crash and ensures the `wait-on` can be run even if it was previously deleted for any reason.